### PR TITLE
Update instructions and scripts for data pre-processing

### DIFF
--- a/datasets_preprocess/preprocess_mapfree2.py
+++ b/datasets_preprocess/preprocess_mapfree2.py
@@ -28,7 +28,7 @@ def main(rootdir, outdir):
         subseqs = [
             f
             for f in os.listdir(osp.join(rootdir, env))
-            if os.path.isdir(osp.join(rootdir, env, f))
+            if os.path.isdir(osp.join(rootdir, env, f)) and 'dense' in f
         ]
         for subseq in subseqs:
             sparse_dir = osp.join(rootdir, env, subseq, "sparse")

--- a/datasets_preprocess/preprocess_unreal4k.py
+++ b/datasets_preprocess/preprocess_unreal4k.py
@@ -1,19 +1,13 @@
-import argparse
-import random
-import gzip
-import json
 import os
 import os.path as osp
-import torch
-import PIL.Image
 from PIL import Image
 import numpy as np
-import cv2
 from tqdm import tqdm
-import matplotlib.pyplot as plt
-import shutil
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 import src.dust3r.datasets.utils.cropping as cropping  # noqa
-from scipy.spatial.transform import Rotation as R
 
 
 def get_parser():

--- a/docs/preprocess.md
+++ b/docs/preprocess.md
@@ -272,12 +272,12 @@ python3 preprocess_wildrgbd.py --wildrgbd_dir /path/to/your/raw/data --output_di
 
 First preprocess the colmap results provided by Mapfree:
 ```
-python3 preprocess_mapfree.py --mapfree_dir /path/to/train/data --colmap_dir /path/to/colmap/data --output_dir  /path/to/first/outdir
+python3 preprocess_mapfree.py --mapfree_dir /path/to/train/data --colmap_dir /path/to/colmap/data # --output_dir  /path/to/first/outdir
 ```
 
 Then re-organize the data structure:
 ```
-python3 preprocess_mapfree2.py --mapfree_dir /path/to/first/outdir --output_dir  /path/to/final/outdir
+python3 preprocess_mapfree2.py --mapfree_dir /path/to/colmap/data --output_dir  /path/to/final/outdir
 ```
 
 Finally, download our released [depths and masks](https://drive.google.com/file/d/1gJGEAV5e08CR6nK2gH9i71a7_WJ4ANwc/view?usp=drive_link) and combine it with your `/path/to/final/outdir`.


### PR DESCRIPTION
Hi, thanks for sharing the scripts and results for data preprocessing!

In this pull request, I fix minor problems in instructions and scripts for data processing

## Update `preprocess_mapfree2.py`
- match the pipeline with MVS results released.

Given the colmap folder shown below after running `preprocess_mapfree.py`, there exist four folders in each scene folder, among which `seq0` and `seq1` should be excluded from parsing in `preprocess_mapfree2.py`.
```shell
mapfree 
  |_ colmap
      |_ s00001
          |_ seq0	# unexpected (downloaded sparse COLMAP results from the official website of MapFree)
          |   |_ cameras.bin
          |   |_ images.bin
          |   |_ points3D.bin
          |   |_ cameras.bin
          |
          |_ seq1	# unexpected (downloaded sparse COLMAP results from the official website of MapFree)
          |   |_ ...
          |
          |_ dense0	# expected (from preprocess_mapfree.py)
          |   |_ images
          |   |_ sparse
          |   |_ stereo
          |   |_ run-colmap-geometric.sh
          |   |_ run-colmap-photometric.sh
          |
          |_ dense1	# expected (from preprocess_mapfree.py)
              |_ ...
```

## Update `preprocess_unreal4k.py` 
- fix path problems


